### PR TITLE
Disable eslint for template of privacy policy

### DIFF
--- a/src/views/PrivacyPolicy.vue
+++ b/src/views/PrivacyPolicy.vue
@@ -1,4 +1,5 @@
 <template>
+  <!-- eslint-disable -->
     <div class="auditions">
         <section class="hero is-link is-bold is-fullheight">
             <section class="hero">


### PR DESCRIPTION
This is important for linelength > 100

Gets rid of all of the warnings in ESLint