### PR TITLE
Apply navbar fix per bulma documentation

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,7 @@
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
     <title>coloradomormonchorale</title>
   </head>
-  <body>
+  <body class="has-navbar-fixed-top">
     <noscript>
       <strong>We're sorry but coloradomormonchorale doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
     </noscript>


### PR DESCRIPTION
There is an issue that will affect all other components. It is found at the following link.
https://bulma.io/documentation/components/navbar/#fixed-navbar

I just went ahead and merge this into master since the fix is probably harmless.

Here's an example of what the change will do if you apply section and container under the navbar. Notice that in the second image (before the fix), that the content is not properly displayed below the navbar.

<img width="1206" alt="screen shot 2018-11-03 at 11 03 05 pm" src="https://user-images.githubusercontent.com/8978605/47960828-19892a00-dfbe-11e8-96b6-ce69c21a9d56.png">
<img width="1225" alt="screen shot 2018-11-03 at 11 03 23 pm" src="https://user-images.githubusercontent.com/8978605/47960829-19892a00-dfbe-11e8-9591-be2ec30d39a4.png">
